### PR TITLE
feat: added stack autodiscovery example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This example demonstrates how to manage Spacelift environment variables using a 
 ### [extract labels](extract_labels/)
 A Go tool that statically parses Terraform/OpenTofu HCL and reports the labels applied to stacks created via the `terraform-spacelift-stack` module.
 
+### [stack autodiscovery](stack_autodiscovery/)
+An administrative stack that scans a directory in the repository and creates one Spacelift stack per subdirectory it finds, so adding a stack is just adding a directory.
+
 ## Getting Started
 
 1. Choose an example that matches your use case

--- a/stack_autodiscovery/README.md
+++ b/stack_autodiscovery/README.md
@@ -1,0 +1,176 @@
+# Stack Autodiscovery
+
+This example demonstrates how to have one administrative stack create a Spacelift
+stack for every directory it finds on disk, so that adding a stack becomes "add a
+directory and open a pull request" instead of "write more Terraform".
+
+## Overview
+
+An administrative stack scans a directory in the repository with `fileset()` at
+plan time. Every subdirectory that contains at least one file is turned into a
+stack via the `stacks-module` module from the Spacelift module registry
+(the [terraform-spacelift-stack](https://github.com/spacelift-solutions/terraform-spacelift-stack)
+module, published to `spacelift.io`), with a name and an `env:` label derived
+from the directory path.
+
+Because the discovery happens in Terraform, no stack definitions are duplicated
+and nothing has to be kept in sync by hand: the filesystem is the source of
+truth.
+
+## Prerequisites
+
+The module is consumed from the Spacelift module registry:
+
+```hcl
+source = "spacelift.io/spacelift-solutions/stacks-module/spacelift"
+```
+
+That source resolves against your own account's registry, so `stacks-module`
+needs to be published there before a run can initialise. Spacelift injects the
+registry credentials automatically inside a run; a `terraform init` from a
+laptop returns `401 Unauthorized` unless you configure credentials for
+`spacelift.io` yourself.
+
+## Structure
+
+- `admin/autodiscovery.tf` - discovery logic and the `module` block that creates the stacks
+- `admin/variables.tf` - inputs (source root, scanned directory, repository, space)
+- `admin/outputs.tf` - the discovered stack map, handy for inspecting a plan
+- `admin/providers.tf` - Spacelift provider configuration
+- `autodiscovery/` - the scanned directory; each subdirectory here becomes a stack
+
+The sample tree ships three directories:
+
+```
+autodiscovery/
+├── dev/
+│   ├── app/main.tf
+│   └── network/main.tf
+└── prod/
+    └── network/main.tf
+```
+
+## How it Works
+
+1. **Locate the source on disk.** Inside a Spacelift run the repository is always
+   checked out at `/mnt/workspace/source/`, which is the default of
+   `var.source_root`. This is the whole repository, not the stack's
+   `project_root`, so `var.autodiscover_directory` is relative to the repository
+   root.
+
+2. **Find the directories.** `fileset()` returns every file under the scanned
+   directory, `dirname()` reduces each to its directory, and `distinct()` removes
+   the duplicates that come from directories holding more than one file:
+
+   ```hcl
+   discovered_directories = [
+     for dir in distinct([
+       for _, v in fileset("${local.abs_source}${local.autodiscover_directory}", "**") : dirname(v)
+     ]) : dir if dir != "."
+   ]
+   ```
+
+   `fileset()` only ever returns files, so an empty directory is never
+   discovered. `"."` is filtered out because it represents a file sitting
+   directly in the scanned directory (a `README.md`, for example) rather than a
+   stack.
+
+3. **Derive each stack's attributes.** The directory path becomes a map key so
+   `for_each` gets a stable identity per stack:
+
+   ```hcl
+   discovered_stacks = {
+     for k, v in local.discovered_directories : v =>
+     {
+       path : "${local.autodiscover_directory}/${v}",
+       env : regex("([a-z]+)", v)[0],
+       stack_name : "auto-discovered-${replace(v, "/", "-")}"
+     }
+   }
+   ```
+
+   - `path` is the stack's `project_root`, relative to the repository root
+   - `env` is the first run of lowercase letters in the path, i.e. the top-level
+     directory name
+   - `stack_name` flattens the path, so `dev/network` becomes
+     `auto-discovered-dev-network`
+
+4. **Create the stacks.** The module is called once per entry, and each stack is
+   labelled with its environment plus `autodiscovered`, which makes the generated
+   stacks easy to find and easy to target with policies.
+
+For the sample tree the resulting map is:
+
+```hcl
+discovered_stacks = {
+  "dev/app" = {
+    "env"        = "dev"
+    "path"       = "stack_autodiscovery/autodiscovery/dev/app"
+    "stack_name" = "auto-discovered-dev-app"
+  }
+  "dev/network" = {
+    "env"        = "dev"
+    "path"       = "stack_autodiscovery/autodiscovery/dev/network"
+    "stack_name" = "auto-discovered-dev-network"
+  }
+  "prod/network" = {
+    "env"        = "prod"
+    "path"       = "stack_autodiscovery/autodiscovery/prod/network"
+    "stack_name" = "auto-discovered-prod-network"
+  }
+}
+```
+
+## Usage
+
+1. Create the administrative stack in Spacelift, pointing at this repository with
+   `stack_autodiscovery/admin` as the project root, and mark it as administrative
+   so it is allowed to manage Spacelift resources.
+
+2. Point `var.autodiscover_directory` at the directory you want scanned and
+   `var.repository_name` at your repository. The defaults match this example
+   (`stack_autodiscovery/autodiscovery` in the `examples` repository).
+
+3. Trigger a run. The administrative stack creates one stack per discovered
+   directory.
+
+4. To add a stack, add a directory with at least one file in it and merge. To
+   remove a stack, delete its directory: the next administrative run destroys the
+   stack.
+
+Because discovery reads the filesystem, the administrative stack must re-run
+whenever the scanned tree changes. Give it a push policy that triggers on changes
+under both `stack_autodiscovery/admin` and `stack_autodiscovery/autodiscovery`,
+or leave it on the default behaviour of tracking the whole project.
+
+### Inspecting discovery outside of Spacelift
+
+`var.source_root` exists because `/mnt/workspace/source/` only exists inside a
+Spacelift run. Point it at a checkout to see what would be discovered, for
+example from `admin/`:
+
+```bash
+terraform console -var 'source_root=../../'
+```
+
+then evaluate `local.discovered_stacks`. This needs `terraform init` to have
+succeeded, so it only works where the module registry is reachable (see
+Prerequisites). Otherwise, read the `discovered_stacks` output from the
+administrative stack's run in Spacelift, which reports the same map.
+
+## Things to Watch Out For
+
+- **Directory names should be lowercase.** `env` comes from
+  `regex("([a-z]+)", v)`, which matches the first run of lowercase letters. A
+  directory named `PROD/api` yields `env:api`, not `env:prod`, because `PROD` has
+  no lowercase characters. A path with no lowercase letters at all makes the
+  regex fail and the run error out.
+- **Hidden files count as files.** `fileset()` with `**` matches dotfiles, so a
+  directory containing only a `.keep` becomes a stack whose Terraform code is
+  empty.
+- **Renaming a directory replaces a stack.** The directory path is the `for_each`
+  key, so a rename is a destroy plus a create, not an update. Move the state or
+  accept the recreation.
+- **Discovery happens at plan time.** The stack list reflects the commit the
+  administrative run is planning, which is why the administrative stack needs to
+  run on changes to the scanned directory.

--- a/stack_autodiscovery/admin/autodiscovery.tf
+++ b/stack_autodiscovery/admin/autodiscovery.tf
@@ -1,0 +1,46 @@
+locals {
+  # Where the source code is located on disk. Inside Spacelift this is always
+  # /mnt/workspace/source/, so var.source_root only changes for local plans.
+  abs_source = var.source_root
+
+  # Path where auto discovered stacks will be located.
+  # Must be from the root of the repository.
+  autodiscover_directory = var.autodiscover_directory
+
+  # Get all unique directories with files in them from the autodiscovery
+  # directory. fileset() only returns files, so a directory without any files
+  # in it is never discovered. "." is the autodiscovery directory itself and is
+  # dropped: it is not a stack.
+  discovered_directories = [
+    for dir in distinct([
+      for _, v in fileset("${local.abs_source}${local.autodiscover_directory}", "**") : dirname(v)
+    ]) : dir if dir != "."
+  ]
+
+  # Break the discovered directories out into a map of
+  # directory => {path, env, stack_name}
+  discovered_stacks = {
+    for k, v in local.discovered_directories : v =>
+    {
+      path : "${local.autodiscover_directory}/${v}",
+      env : regex("([a-z]+)", v)[0],
+      stack_name : "auto-discovered-${replace(v, "/", "-")}"
+    }
+  }
+}
+
+module "autodiscovered_stack" {
+  source = "spacelift.io/spacelift-solutions/stacks-module/spacelift"
+
+  for_each = local.discovered_stacks
+
+  name              = each.value.stack_name
+  description       = "Autodiscovered stack"
+  repository_name   = var.repository_name
+  repository_branch = var.repository_branch
+  project_root      = each.value.path
+
+  labels = ["env:${each.value.env}", "autodiscovered"]
+
+  space_id = var.space_id
+}

--- a/stack_autodiscovery/admin/outputs.tf
+++ b/stack_autodiscovery/admin/outputs.tf
@@ -1,0 +1,4 @@
+output "discovered_stacks" {
+  description = "The stacks that were discovered on disk, keyed by directory."
+  value       = local.discovered_stacks
+}

--- a/stack_autodiscovery/admin/providers.tf
+++ b/stack_autodiscovery/admin/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    spacelift = {
+      source  = "spacelift-io/spacelift"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "spacelift" {}

--- a/stack_autodiscovery/admin/variables.tf
+++ b/stack_autodiscovery/admin/variables.tf
@@ -1,0 +1,41 @@
+variable "source_root" {
+  type        = string
+  description = <<-EOT
+    Absolute path to the root of the checked out repository. Inside a Spacelift
+    run this is always /mnt/workspace/source/ and should be left alone. Override
+    it when planning from a laptop, e.g. -var 'source_root=../../../'.
+  EOT
+  default     = "/mnt/workspace/source/"
+}
+
+variable "autodiscover_directory" {
+  type        = string
+  description = <<-EOT
+    Directory that is scanned for stacks, relative to the root of the
+    repository. Every subdirectory of it that contains at least one file
+    becomes a stack.
+  EOT
+  default     = "stack_autodiscovery/autodiscovery"
+}
+
+variable "repository_name" {
+  type        = string
+  description = "Repository the discovered stacks are created against."
+  default     = "examples"
+}
+
+variable "repository_branch" {
+  type        = string
+  description = "Branch the discovered stacks track."
+  default     = "main"
+}
+
+variable "space_id" {
+  type        = string
+  description = <<-EOT
+    Space the discovered stacks are created in. When the administrative stack
+    itself runs in Spacelift you can instead point this at the
+    spacelift_current_space data source, as the other examples in this repo do.
+  EOT
+  default     = "root"
+}

--- a/stack_autodiscovery/autodiscovery/dev/app/main.tf
+++ b/stack_autodiscovery/autodiscovery/dev/app/main.tf
@@ -1,0 +1,11 @@
+# Placeholder workload for the auto discovered "dev/app" stack. Replace this with
+# whatever the stack should actually manage.
+resource "null_resource" "this" {
+  triggers = {
+    directory = "dev/app"
+  }
+
+  provisioner "local-exec" {
+    command = "echo running the dev/app stack"
+  }
+}

--- a/stack_autodiscovery/autodiscovery/dev/network/main.tf
+++ b/stack_autodiscovery/autodiscovery/dev/network/main.tf
@@ -1,0 +1,11 @@
+# Placeholder workload for the auto discovered "dev/network" stack. Replace this with
+# whatever the stack should actually manage.
+resource "null_resource" "this" {
+  triggers = {
+    directory = "dev/network"
+  }
+
+  provisioner "local-exec" {
+    command = "echo running the dev/network stack"
+  }
+}

--- a/stack_autodiscovery/autodiscovery/prod/network/main.tf
+++ b/stack_autodiscovery/autodiscovery/prod/network/main.tf
@@ -1,0 +1,11 @@
+# Placeholder workload for the auto discovered "prod/network" stack. Replace this with
+# whatever the stack should actually manage.
+resource "null_resource" "this" {
+  triggers = {
+    directory = "prod/network"
+  }
+
+  provisioner "local-exec" {
+    command = "echo running the prod/network stack"
+  }
+}


### PR DESCRIPTION
An administrative stack that scans a directory with fileset() and creates one stack per subdirectory found, so adding a stack means adding a directory.